### PR TITLE
Add promotion of player after completion of compulsory tutorial

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,5 +111,11 @@
             <artifactId>guava</artifactId>
             <version>31.0.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/teachingtutorials/utils/plugins/Luckperms.java
+++ b/src/main/java/teachingtutorials/utils/plugins/Luckperms.java
@@ -1,0 +1,52 @@
+package teachingtutorials.utils.plugins;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.track.Track;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.UUID;
+
+public class Luckperms
+{
+    public static Track getTrack(String szTrack)
+    {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider !=null)
+        {
+            LuckPerms api = provider.getProvider();
+            Track track = api.getTrackManager().getTrack(szTrack);
+            return track;
+        }
+        else
+            return null;
+    }
+
+    public static Group getGroup(String szGroup)
+    {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider !=null)
+        {
+            LuckPerms api = provider.getProvider();
+            Group group = api.getGroupManager().getGroup(szGroup);
+            return group;
+        }
+        else
+            return null;
+    }
+
+    public static User getUser(UUID uuid)
+    {
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider !=null)
+        {
+            LuckPerms api = provider.getProvider();
+            User lpUser = api.getUserManager().getUser(uuid);
+            return lpUser;
+        }
+        else
+            return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,8 @@ MySQL_port: 3306
 MySQL_database: TeachingTutorials
 MySQL_username: newuser1
 MySQL_password: xxxx
+Compulsory_Tutorial_Promotion_Type: track
+Compulsory_Tutorial_RankOld: default
+Compulsory_Tutorial_RankNew: applicant
+Compulsory_Tutorial_Track: builder
+Compulsory_Tutorial_TrackOutline: default,applicant,apprentice,jrbuilder,builder,architect,reviewer


### PR DESCRIPTION
Adds 4 options for promotion of a player after completion of compulsory tutorial.
1. None - Player is not promoted at all
2. Track - Player is promoted through an LP track
3. Manualpromote - Player is striped of one rank and given another
4. Rank - Player is given a rank (Added to an LP group)