### PR TITLE
Virtual Blocks and World Edit Mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.bteuk</groupId>
     <artifactId>TeachingTutorials</artifactId>
-    <version>1.1.0-Beta6.1</version>
+    <version>1.1.0-Beta7</version>
     <packaging>jar</packaging>
 
     <name>TeachingTutorials</name>
@@ -93,7 +93,23 @@
             <id>sk89q-repo</id>
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.intellectualsites.bom</groupId>
+                <artifactId>bom-newest</artifactId> <!--  Ref: https://github.com/IntellectualSites/bom -->
+                <version>1.43</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -129,12 +145,30 @@
             <version>5.4</version>
             <scope>provided</scope>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.sk89q.worldedit</groupId>-->
+<!--            <artifactId>worldedit-bukkit</artifactId>-->
+<!--            <version>7.2.10</version>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
+
         <dependency>
-            <groupId>com.sk89q.worldedit</groupId>
-            <artifactId>worldedit-bukkit</artifactId>
-            <version>7.2.10</version>
+            <groupId>com.fastasyncworldedit</groupId>
+            <artifactId>FastAsyncWorldEdit-Core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fastasyncworldedit</groupId>
+            <artifactId>FastAsyncWorldEdit-Bukkit</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>FastAsyncWorldEdit-Core</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <dependency>
             <groupId>me.filoghost.holographicdisplays</groupId>
             <artifactId>holographicdisplays-api</artifactId>

--- a/src/main/java/teachingtutorials/TeachingTutorials.java
+++ b/src/main/java/teachingtutorials/TeachingTutorials.java
@@ -3,6 +3,7 @@ package teachingtutorials;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,19 +17,14 @@ import teachingtutorials.listeners.JoinLeaveEvent;
 import teachingtutorials.listeners.GlobalPlayerCommandProcess;
 import teachingtutorials.newlocation.NewLocation;
 import teachingtutorials.tutorials.*;
-import teachingtutorials.utils.DBConnection;
-import teachingtutorials.utils.Display;
-import teachingtutorials.utils.User;
-import teachingtutorials.utils.VirtualBlock;
+import teachingtutorials.utils.*;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.Scanner;
-import java.util.UUID;
+import java.util.*;
 
 public class TeachingTutorials extends JavaPlugin
 {
@@ -56,7 +52,7 @@ public class TeachingTutorials extends JavaPlugin
     public ArrayList<NewLocation> newLocations;
 
     //A list of all virtual blocks
-    public ArrayList<VirtualBlock> virtualBlocks;
+    public HashMap<VirtualBlockLocation, BlockData> virtualBlocks;
 
     @Override
     public void onEnable()
@@ -92,7 +88,7 @@ public class TeachingTutorials extends JavaPlugin
         players = new ArrayList<>();
         lessons = new ArrayList<>();
         newLocations = new ArrayList<>();
-        virtualBlocks = new ArrayList<>();
+        virtualBlocks = new HashMap<>();
 
         //-------------------------------------------------------------------------
         //----------------------------------MySQL----------------------------------
@@ -220,17 +216,16 @@ public class TeachingTutorials extends JavaPlugin
         //----------------------------------------
         //--------Refreshes virtual blocks--------
         //----------------------------------------
-        this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable()
+        this.getServer().getScheduler().scheduleSyncRepeatingTask(this, () ->
         {
-            @Override
-            public void run()
+            int iSize;
+            iSize = virtualBlocks.size();
+            VirtualBlockLocation[] locations = virtualBlocks.keySet().toArray(VirtualBlockLocation[]::new);
+            BlockData[] blockData = virtualBlocks.values().toArray(BlockData[]::new);
+
+            for (int i = 0 ; i < iSize ; i++)
             {
-                int i;
-                int iNumVirtualBlocks = virtualBlocks.size();
-                for (i = 0 ; i < iNumVirtualBlocks ; i++)
-                {
-                    virtualBlocks.get(i).sendUpdate();
-                }
+                locations[i].sendUpdate(blockData[i]);
             }
         }, 0, 10);
 

--- a/src/main/java/teachingtutorials/TutorialPlaythrough.java
+++ b/src/main/java/teachingtutorials/TutorialPlaythrough.java
@@ -1,6 +1,7 @@
 package teachingtutorials;
 
 import org.bukkit.Bukkit;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.file.FileConfiguration;
 import teachingtutorials.listeners.Falling;
 import teachingtutorials.tutorials.Location;
@@ -8,9 +9,10 @@ import teachingtutorials.tutorials.Stage;
 import teachingtutorials.tutorials.Tutorial;
 import teachingtutorials.utils.Mode;
 import teachingtutorials.utils.User;
-import teachingtutorials.utils.VirtualBlock;
+import teachingtutorials.utils.VirtualBlockLocation;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 //To be extended by lesson and new location
 //They both share a lot of data and processes, and they are also rather similar in the user experience as well
@@ -88,19 +90,17 @@ public abstract class TutorialPlaythrough
         fallListener.unregister();
 
         //Removes virtual blocks
-        int i;
-        ArrayList<VirtualBlock> virtualBlocks = plugin.virtualBlocks;
-        int iVirtualBlocks = virtualBlocks.size();
-        VirtualBlock virtualBlock;
-        for (i = 0 ; i < iVirtualBlocks ; i++)
+        HashMap<VirtualBlockLocation, BlockData> virtualBlocks = plugin.virtualBlocks;
+        int iSize;
+        iSize = virtualBlocks.size();
+        VirtualBlockLocation[] locations = virtualBlocks.keySet().toArray(VirtualBlockLocation[]::new);
+
+        for (int i = 0 ; i < iSize ; i++)
         {
-            virtualBlock = virtualBlocks.get(i);
-            if (virtualBlock.isFromTutorial(this))
+            if (locations[i].isFromTutorial(this))
             {
-                virtualBlocks.remove(i);
-                virtualBlock.removeAndReset();
-                iVirtualBlocks--;
-                i--;
+                virtualBlocks.remove(locations[i]);
+                locations[i].removeAndReset();
             }
         }
 
@@ -120,7 +120,7 @@ public abstract class TutorialPlaythrough
         {
             String szServerName = config.getString("Server_Name");
 
-            //Switches the player's server after 40 seconds
+            //Switches the player's server after 2 seconds
             Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> creatorOrStudent.player.performCommand("server " +szServerName), 40L);
         }
 

--- a/src/main/java/teachingtutorials/fundamentalTasks/Place.java
+++ b/src/main/java/teachingtutorials/fundamentalTasks/Place.java
@@ -51,6 +51,7 @@ public class Place extends Task implements Listener
 
         this.fDifficulty = fDifficulty;
 
+        //Calculates the virtual block
         calculateVirtualBlocks();
     }
 
@@ -223,11 +224,14 @@ public class Place extends Task implements Listener
         spotHit();
     }
 
+    /**
+     * Uses the target coords and target material to calculate the virtual block
+     */
     public void calculateVirtualBlocks()
     {
         VirtualBlock virtualPlaceBlock = new VirtualBlock(this.parentGroup.parentStep.parentStage.tutorialPlaythrough, player, player.getWorld(),
                                                         iTargetCoords[0], iTargetCoords[1], iTargetCoords[2],
-                                                        mTargetMaterial);
-        this.virtualBlocks = new VirtualBlock[]{virtualPlaceBlock};
+                                                        mTargetMaterial.createBlockData());
+        this.virtualBlocks.add(virtualPlaceBlock);
     }
 }

--- a/src/main/java/teachingtutorials/tutorials/Step.java
+++ b/src/main/java/teachingtutorials/tutorials/Step.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 import teachingtutorials.TeachingTutorials;
 import teachingtutorials.fundamentalTasks.TpllListener;
 import teachingtutorials.guis.locationcreatemenus.StepEditorMenu;
@@ -230,8 +231,15 @@ public class Step
 
             for (i = 0; i < iGroups; i++)
             {
-                groups.get(i).initialRegister();
-                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Registered group "+(i+1));
+                final int I = i;
+                //Registers each group 0.2 seconds apart from each other - this is to allow all world edit block calculations to complete
+                //WE block calculations involves running the WE command over the console and detecting and recording changes, before
+                // then removing those changes from the actual world. This involves delicate use of listeners, hence this 0.1 second control
+                Bukkit.getScheduler().runTaskLater(TeachingTutorials.getInstance(), () ->
+                {
+                    groups.get(I).initialRegister();
+                    Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Registered group "+(I+1));
+                }, i*4L);
             }
 
             //TP to start location, and store this location for later use

--- a/src/main/java/teachingtutorials/utils/BlockChangeListener.java
+++ b/src/main/java/teachingtutorials/utils/BlockChangeListener.java
@@ -1,0 +1,38 @@
+package teachingtutorials.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServerCommandEvent;
+import teachingtutorials.TeachingTutorials;
+
+public class BlockChangeListener implements Listener
+{
+    private TeachingTutorials plugin;
+    private Object worldEditEventListener;
+
+    public BlockChangeListener(TeachingTutorials plugin, Object worldEditEventListener)
+    {
+        this.plugin = plugin;
+        this.worldEditEventListener = worldEditEventListener;
+
+        //Registers the listener
+        Bukkit.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    //Lowest will mean that it can be recorded and then immediately cancelled. It yet be uncancelled, but this is highly unlikely
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void blockChangeEvent(ServerCommandEvent event)
+    {
+        //Checks that it is the correct command
+        String command = event.getCommand();
+        if (command.startsWith("/tpll"))
+        {
+            //Cancels the event
+            event.setCancelled(true);
+
+        }
+    }
+}

--- a/src/main/java/teachingtutorials/utils/VirtualBlock.java
+++ b/src/main/java/teachingtutorials/utils/VirtualBlock.java
@@ -3,6 +3,7 @@ package teachingtutorials.utils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import teachingtutorials.TutorialPlaythrough;
 
@@ -13,41 +14,66 @@ public class VirtualBlock
     //Technically the TutorialPlaythrough could iterate through all stages, steps, groups and tasks to disable the virtual blocks but
     //this would be quite resource intensive (involves iterating through the virtual blocks list for every task and ultimately
     //the exact same code could be run just using the tutorial playthrough check but just with one iteration through the list
-    private TutorialPlaythrough tutorialPlaythrough;
+    public VirtualBlockLocation blockLocation;
+    public BlockData blockData;
 
-    public Player player;
-    private int iBlockX, iBlockY, iBlockZ;
-    public Material material;
 
-    public Location location;
-
-    public VirtualBlock(TutorialPlaythrough tutorialPlaythrough, Player player, World world, int iBlockX, int iBlockY, int iBlockZ, Material material)
+    /**
+     * Constructs the virtual block. Use this if the bukkit location object for this block has not yet been created
+     * @param tutorialPlaythrough
+     * @param player
+     * @param world
+     * @param iBlockX
+     * @param iBlockY
+     * @param iBlockZ
+     * @param blockData
+     */
+    public VirtualBlock(TutorialPlaythrough tutorialPlaythrough, Player player, World world, int iBlockX, int iBlockY, int iBlockZ, BlockData blockData)
     {
-        this.tutorialPlaythrough = tutorialPlaythrough;
-        this.player = player;
+        //Calculates the location
+        Location location = new Location(world, iBlockX, iBlockY, iBlockZ);
 
-        this.iBlockX = iBlockX;
-        this.iBlockY = iBlockY;
-        this.iBlockZ = iBlockZ;
-        this.material = material;
+        this.blockLocation = new VirtualBlockLocation(tutorialPlaythrough, player, location);
 
-        this.location = new Location(world, iBlockX, iBlockY, iBlockZ);
+        this.blockData = blockData;
     }
 
+    /**
+     * Constructs the virtual block. Use this if the bukkit location object for this block has already been created and initialised
+     * @param tutorialPlaythrough
+     * @param player
+     * @param location
+     * @param blockData
+     */
+    public VirtualBlock(TutorialPlaythrough tutorialPlaythrough, Player player, Location location, BlockData blockData)
+    {
+        this.blockLocation = new VirtualBlockLocation(tutorialPlaythrough, player, location);
+        this.blockData = blockData;
+    }
+
+    /**
+     * Sends the virtual block change to the player
+     */
     public void sendUpdate()
     {
-        //Sends the virtual block change to the player
-        player.sendBlockChange(location, material.createBlockData());
+        this.blockLocation.player.sendBlockChange(this.blockLocation.location, blockData);
     }
 
+    /**
+     * Returns the player's view of the block to match the actual world
+     */
     public void removeAndReset()
     {
-        //Returns the block to match the actual world
-        player.sendBlockChange(location, location.getBlock().getBlockData());
+        this.blockLocation.player.sendBlockChange(this.blockLocation.location, this.blockLocation.location.getBlock().getBlockData());
     }
 
+    /**
+     * Returns whether the virtual block is one created by the given tutorial
+     */
     public boolean isFromTutorial(TutorialPlaythrough tutorialPlaythrough)
     {
-        return tutorialPlaythrough.equals(this.tutorialPlaythrough);
+        return this.blockLocation.isFromTutorial(tutorialPlaythrough);
     }
+
+    //A util class for converting a list of them to one thing?
 }

--- a/src/main/java/teachingtutorials/utils/VirtualBlockLocation.java
+++ b/src/main/java/teachingtutorials/utils/VirtualBlockLocation.java
@@ -1,0 +1,50 @@
+package teachingtutorials.utils;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import teachingtutorials.TutorialPlaythrough;
+
+/**
+ * Locates a virtual block via its location in the world and the tutorial playthrough it belongs to
+ */
+public class VirtualBlockLocation
+{
+    private TutorialPlaythrough tutorialPlaythrough;
+    protected Player player;
+    protected Location location;
+
+    public VirtualBlockLocation(TutorialPlaythrough tutorialPlaythrough, Player player, Location location)
+    {
+        this.tutorialPlaythrough = tutorialPlaythrough;
+        this.player = player;
+
+        this.location = location;
+    }
+
+    /**
+     * Sends the virtual block change to the player
+     * @param blockData The block data to send to the player for the location
+     */
+    public void sendUpdate(BlockData blockData)
+    {
+        this.player.sendBlockChange(this.location, blockData);
+    }
+
+    /**
+     * Returns the player's view of the block to match the actual world
+     */
+    public void removeAndReset()
+    {
+        this.player.sendBlockChange(this.location, this.location.getBlock().getBlockData());
+    }
+
+    /**
+     * Returns whether the virtual block is one created by the given tutorial
+     */
+    public boolean isFromTutorial(TutorialPlaythrough tutorialPlaythrough)
+    {
+        return this.tutorialPlaythrough.equals(tutorialPlaythrough);
+    }
+}

--- a/src/main/java/teachingtutorials/utils/WorldEdit.java
+++ b/src/main/java/teachingtutorials/utils/WorldEdit.java
@@ -13,125 +13,252 @@ package teachingtutorials.utils;
 //import com.sk89q.worldedit.session.SessionManager;
 //import com.sk89q.worldedit.session.SessionOwner;
 //import org.apache.commons.lang.WordUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.World;
+import com.google.common.base.Joiner;
+import com.sk89q.worldedit.*;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.BukkitCommandSender;
+import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.command.RegionCommands;
+import com.sk89q.worldedit.event.Event;
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.event.platform.CommandEvent;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.extension.platform.AbstractNonPlayerActor;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.extension.platform.PlatformCommandManager;
+import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
+import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
+import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.function.operation.Operation;
+import com.sk89q.worldedit.function.pattern.AbstractPattern;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.history.UndoContext;
+import com.sk89q.worldedit.history.change.Change;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.regions.RegionSelector;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import com.sk89q.worldedit.regions.selector.RegionSelectorType;
+import com.sk89q.worldedit.session.ClipboardHolder;
+import com.sk89q.worldedit.session.SessionKey;
+import com.sk89q.worldedit.session.SessionManager;
+import com.sk89q.worldedit.session.SessionOwner;
+import com.sk89q.worldedit.util.auth.AuthorizationException;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.world.AbstractWorld;
+import com.sk89q.worldedit.world.NullWorld;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.weather.WeatherTypes;
+import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.util.BlockVector;
+import org.enginehub.piston.CommandManager;
+import teachingtutorials.TeachingTutorials;
+import teachingtutorials.TutorialPlaythrough;
+import teachingtutorials.fundamentalTasks.Command;
+import teachingtutorials.utils.plugins.WorldGuard;
 
-import java.util.ArrayList;
+import javax.print.DocFlavor;
+import java.util.*;
 
 public class WorldEdit
 {
-    public static ArrayList<Location> BlocksCalculator(String szCommand, int[] iSelectedBlockCoordinates1, int[] iSelectedBlockCoordinates2, String szWorld)
+    private static Object worldEditEditEvent;
+
+    /**
+     * Creates a world edit event listener which catches the block changes arising from world edit commands owned by the given player
+     * and creates virtual block objects from these. The specific command parsed is then run, triggering the calculation of all blocks
+     * changes from this command.
+     * @param virtualBlocks The list of virtual blocks for the calling task
+     * @param szCommandLabel The command label (first word) of the command
+     * @param szCommandArgs The command args
+     * @param bukkitWorld The bukkit world for this set of blocks
+     * @param player The player doing the task
+     * @param tutorialPlaythrough The tutorial playthrough which this task belongs to
+     * @return
+     */
+    public static void BlocksCalculator(int iTaskID, final HashSet<VirtualBlock> virtualBlocks, RegionSelector correctSelectionRegion, String szCommandLabel, String[] szCommandArgs, World bukkitWorld, Player player, TutorialPlaythrough tutorialPlaythrough)
     {
-        World bukkitWorld = Bukkit.getWorld(szWorld);
+        //Get instance
+        com.sk89q.worldedit.WorldEdit worldEdit = com.sk89q.worldedit.WorldEdit.getInstance();
 
-        //Refer back to elgamer code. See how the line works there. Add more debug output, work out where the blocks are actually being placed
+//        //Get the session manager
+//        SessionManager sessionManager = worldEdit.getSessionManager();
 
-//        World world = new BukkitWorld(Bukkit.getWorld(szWorld));
-//        EditSession editSession = com.sk89q.worldedit.WorldEdit.getInstance().newEditSession(world);
+        //Get the console actor
+        Actor consoleActor = BukkitAdapter.adapt(Bukkit.getConsoleSender());
+
+//        //Create an edit session for the console
+//        EditSession consoleEditSession = worldEdit.newEditSessionBuilder().world(correctSelectionRegion.getWorld()).actor(consoleActor).build();
 //
-//        com.sk89q.worldedit.WorldEdit.getInstance().getSessionManager().getIfPresent( )
+//        //Get the local session of the console and set the edit session there
+//        LocalSession tempLocalSession = sessionManager.get(consoleActor);
+////        tempLocalSession.remember(consoleEditSession);
 //
-//        BlockVector3 point1 = BlockVector3.at(xz1[0], iY1, xz1[1]);
-//        BlockVector3 point2 = BlockVector3.at(xz1[0], iY2, xz1[1]);
-//        CuboidRegion cuboidRegion = new CuboidRegion(world, point1, point2);
-//        BlockArrayClipboard clipboard = new BlockArrayClipboard(cuboidRegion);
-//        editSession.drawLine()
+////        //Get the player's edit session
+////        LocalSession localSession = sessionManager.get(WEPlayer);
 //
-//        Operation operation = new ClipboardHolder();
-
-
-        //In this method, see if you can utilise the world edit api
-        ArrayList<Location> line = null;
-
-        if (szCommand.startsWith("/line"))
+////        //Get the player's selection limits
+////        ActorSelectorLimits selectionLimits = ActorSelectorLimits.forActor(WEPlayer);
+//
+////        //Injects the new selection - adjusts the player's selection
+////        playersRegionSelector.selectPrimary(correctSelectionRegion.getMinimumPoint(), selectionLimits);
+////        playersRegionSelector.selectSecondary(correctSelectionRegion.getMaximumPoint(), selectionLimits);
+//
+////        //Gets the player
+////        com.sk89q.worldedit.entity.Player WEPlayer = ;
+//        //Get the player's selection limits
+//        ActorSelectorLimits selectionLimits = ActorSelectorLimits.forActor(BukkitAdapter.adapt(player));
+//
+//        //Gets the temp actor's selection and sets the selection points
+//        RegionSelector actorRegionSelector = tempLocalSession.getRegionSelector(correctSelectionRegion.getWorld());
+//        actorRegionSelector.selectPrimary(correctSelectionRegion.getMinimumPoint(), selectionLimits);
+//        actorRegionSelector.selectSecondary(correctSelectionRegion.getMaximumPoint(), selectionLimits);
+//
+        //Modifies the command
+        //This code is taken from WorldEdit
+        int plSep = szCommandLabel.indexOf(':');
+        if (plSep >= 0 && plSep < szCommandLabel.length() +1)
         {
-            line = new ArrayList<Location>();
-            int dx = Math.abs(iSelectedBlockCoordinates1[0]-iSelectedBlockCoordinates2[0]);
-            int dy = Math.abs(iSelectedBlockCoordinates1[1]-iSelectedBlockCoordinates2[1]);
-            int dz = Math.abs(iSelectedBlockCoordinates1[2]-iSelectedBlockCoordinates2[2]);
+            szCommandLabel = szCommandLabel.substring(plSep + 1);
+        }
+//        StringBuilder sb = new StringBuilder("/").append(szCommandLabel);
+        StringBuilder sb = new StringBuilder(szCommandLabel);
+//        if (szCommandArgs.length > 0)
+//            sb.append(" ");
+        String szWorldEditCommand = Joiner.on(" ").appendTo(sb, szCommandArgs).toString();
 
-            double dMax = Math.max(Math.max(dx, dz), dy);
+        //The command is now fully formatted correctly
+//        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorial] Command being run via the API: "+szWorldEditCommand);
 
-            int x1 = iSelectedBlockCoordinates1[0];
-            int x2 = iSelectedBlockCoordinates2[0];
-            int y1 = iSelectedBlockCoordinates1[1];
-            int y2 = iSelectedBlockCoordinates2[1];
-            int z1 = iSelectedBlockCoordinates1[2];
-            int z2 = iSelectedBlockCoordinates2[2];
 
-            if (dx + dy + dz == 0)
+        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorial] Command being run via the console: "+szWorldEditCommand);
+
+        //Create the new event listener
+        worldEditEditEvent = new Object()
+        {
+            // The following code is extracted from LogBlock under creative commons.
+            // http://creativecommons.org/licenses/by-nc-sa/3.0/
+
+            @Subscribe
+            public void onEditSessionEvent(EditSessionEvent event)
             {
-                line.add(new Location(bukkitWorld, x1, y1, z1));
-            }
-            else
-            {
-                int tipx;
-                int tipy;
-                int tipz;
-                int domstep;
-                if (dMax == dx)
+                final Actor actor = event.getActor();
+
+//                event.getExtent().getMinimumPoint() = ev
+
+                if (actor==null)// || actor.getUniqueId().equals(tempActor.getUniqueId()))
                 {
-                    for(domstep = 0; domstep <= dx; domstep++)
-                    {
-                        tipx = x1 + domstep * (x2 - x1 > 0 ? 1 : -1);
-                        tipy = (int)Math.round((double)y1 + (double)domstep * (double)dy / (double)dx * (double)(y2 - y1 > 0 ? 1 : -1));
-                        tipz = (int)Math.round((double)z1 + (double)domstep * (double)dz / (double)dx * (double)(z2 - z1 > 0 ? 1 : -1));
-                        line.add(new Location(bukkitWorld, tipx, tipy, tipz));
-                    }
+                    System.out.println("Edit session event detected belonging to a null actor - assuming console - at stage: "+event.getStage().toString());
+                    //Cancel if at a certain stage?
                 }
-                else if (dMax == dy)
+                else if (actor.getSessionKey().equals(consoleActor.getSessionKey()))
                 {
-                    Bukkit.getConsoleSender().sendMessage("It was dy = " +dy);
-                    for(domstep = 0; domstep <= dy; ++domstep)
-                    {
-                        tipy = y1 + domstep * (y2 - y1 > 0 ? 1 : -1);
-                        tipx = (int)Math.round((double)x1 + (double)domstep * (double)dx / (double)dy * (double)(x2 - x1 > 0 ? 1 : -1));
-                        tipz = (int)Math.round((double)z1 + (double)domstep * (double)dz / (double)dy * (double)(z2 - z1 > 0 ? 1 : -1));
-                        Bukkit.getConsoleSender().sendMessage(tipx +", " +tipy +", " +tipz);
-                        line.add(new Location(bukkitWorld, tipx, tipy, tipz));
-                    }
+                    System.out.println("Edit session event detected belonging to the actor we are listening for - at stage: "+event.getStage().toString());
                 }
                 else
                 {
-                    Bukkit.getConsoleSender().sendMessage("It was dz = " +dz);
-                    for(domstep = 0; domstep <= dz; ++domstep)
-                    {
-                        tipz = z1 + domstep * (z2 - z1 > 0 ? 1 : -1);
-                        tipy = (int)Math.round((double)y1 + (double)domstep * (double)dy / (double)dz * (double)(y2 - y1 > 0 ? 1 : -1));
-                        tipx = (int)Math.round((double)x1 + (double)domstep * (double)dx / (double)dz * (double)(x2 - x1 > 0 ? 1 : -1));
-                        Bukkit.getConsoleSender().sendMessage(tipx +", " +tipy +", " +tipz);
-                        line.add(new Location(bukkitWorld, tipx, tipy, tipz));
-                    }
+                    System.out.println("Edit session event detected but doesn't belong to the correct actor, so ignoring");
+                    return;
                 }
+
+                AbstractDelegateExtent blockChangeRecorderExtent = new AbstractDelegateExtent(event.getExtent())
+                {
+                    @Override // Is this not working? It seems to not run this modified setBlock
+                    public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) {
+                        System.out.println("A world edit block change has been detected, recording to the given virtual blocks list");
+                        onBlockChange(position, block);
+                        //return super.setBlock(position, block);
+                        return false; // It's unclear whether this should really be used.
+                        // We don't want it to actually set the block so we can just cancel the whole event, but we do also want to set the block or at least try to
+                    }
+
+
+                    protected <B extends BlockStateHolder<B>> void onBlockChange(BlockVector3 pt, B block)
+                    {
+//                        //This should only ever be a specific stage anyway
+//                        if (event.getStage() != EditSession.Stage.BEFORE_CHANGE) {
+//                            return;
+//                        }
+                        //Unregisters the event and deletes the world guard region after 0.5 seconds (10 ticks)
+                        Bukkit.getScheduler().runTaskLater(TeachingTutorials.getInstance(), () ->
+                        {
+                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistering world edit listener");
+                            worldEdit.getEventBus().unregister(worldEditEditEvent);
+                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistered world edit listener");
+                        }, 10L);
+
+
+                        //Calculates the old block
+                        Location location = BukkitAdapter.adapt(bukkitWorld, pt);
+                        Block blockBefore = location.getBlock();
+                        BlockData blockDataBefore = blockBefore.getBlockData();
+
+                        //Gets the new block
+                        BlockData blockDataNew = BukkitAdapter.adapt(block);
+
+                        //If there is actually a change of block
+                        if (!blockDataBefore.equals(blockDataNew))
+                        {
+                            //Creates a virtual block
+                            VirtualBlock virtualBlock = new VirtualBlock(tutorialPlaythrough, player, location, blockDataNew);
+                            //Adds it to the new list
+                            virtualBlocks.add(virtualBlock);
+                        }
+                    }
+                };
+
+                event.getExtent().setBlock() // Try this maybe
+
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Setting the extent");
+                event.setExtent(blockChangeRecorderExtent);
+
+                event.getExtent().setBlock() // Try this maybe
             }
+        };
 
-//            line = new ArrayList<Location>();
-//            Location l;
+        //Temporarily block player's world edit output
+//        To do;
+        //If we create a new actor then it should be fine right?
+        //As long as we extract the selection correctly
+
+        //Temporarily allow worldguard access
+        //Tbh just make it the whole world
+//        WorldGuard.addToGlobalRegion(bukkitWorld, player);
+//        WorldGuard.createNewRegion(iTaskID+"", BukkitAdapter.adapt(bukkitWorld), player, correctSelectionRegion.getMinimumPoint(), correctSelectionRegion.getMaximumPoint());
+
+//        //Performs the WE command via the API
+//        CommandEvent commandEvent = new CommandEvent(consoleActor, szWorldEditCommand);
+//        PlatformCommandManager platformCommandManager = worldEdit.getPlatformManager().getPlatformCommandManager();
 //
-//            for (int i = 1; i < divider; i++)
-//            {
-//                l = new Location(Bukkit.getWorld(szWorld), minX + i * (diffX / divider), xz1[1], minZ + i * (diffZ / divider));
-//                line.add(l);
-//            }
-        }
-        return line;
-    }
+        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Sending command: "+szWorldEditCommand);
+//        platformCommandManager.handleCommand(commandEvent);
+        Bukkit.getScheduler().runTask(TeachingTutorials.getInstance(), () ->
+        {
+            try
+            {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Adjusting the selection");
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/world "+tutorialPlaythrough.getLocation().getLocationID());
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/pos1 " + ((CuboidRegion) correctSelectionRegion.getRegion()).getPos1().toParserString());
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/pos2 " + ((CuboidRegion) correctSelectionRegion.getRegion()).getPos2().toParserString());
 
-    public static BlockData BlockTypeCalculator(String szCommandArgs)
-    {
-        BlockData blockData;
-        try
-        {
-            blockData = Bukkit.createBlockData(Material.valueOf(szCommandArgs.toUpperCase()));
-        }
-        catch (Exception e)
-        {
-            blockData = Bukkit.createBlockData(Material.STONE);
-            e.printStackTrace();
-        }
-        return blockData;
+                //Register the event
+                worldEdit.getEventBus().register(worldEditEditEvent);
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] World edit change event listener registered");
+
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Sending the command");
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), szWorldEditCommand);
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Command sent");
+            }
+            catch (IncompleteRegionException e)
+            {
+
+            }
+        });
     }
 }

--- a/src/main/java/teachingtutorials/utils/WorldEdit.java
+++ b/src/main/java/teachingtutorials/utils/WorldEdit.java
@@ -1,70 +1,27 @@
 package teachingtutorials.utils;
 
-//import com.sk89q.worldedit.EditSession;
-//import com.sk89q.worldedit.LocalSession;
-//import com.sk89q.worldedit.bukkit.BukkitWorld;
-//import com.sk89q.worldedit.entity.Player;
-//import com.sk89q.worldedit.extension.platform.Actor;
-//import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
-//import com.sk89q.worldedit.function.operation.Operation;
-//import com.sk89q.worldedit.math.BlockVector3;
-//import com.sk89q.worldedit.regions.CuboidRegion;
-//import com.sk89q.worldedit.session.ClipboardHolder;
-//import com.sk89q.worldedit.session.SessionManager;
-//import com.sk89q.worldedit.session.SessionOwner;
-//import org.apache.commons.lang.WordUtils;
 import com.google.common.base.Joiner;
-import com.sk89q.worldedit.*;
+import com.sk89q.worldedit.IncompleteRegionException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitCommandSender;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
-import com.sk89q.worldedit.command.RegionCommands;
-import com.sk89q.worldedit.event.Event;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
-import com.sk89q.worldedit.event.platform.CommandEvent;
-import com.sk89q.worldedit.extension.input.ParserContext;
-import com.sk89q.worldedit.extension.platform.AbstractNonPlayerActor;
 import com.sk89q.worldedit.extension.platform.Actor;
-import com.sk89q.worldedit.extension.platform.PlatformCommandManager;
-import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
 import com.sk89q.worldedit.extent.AbstractDelegateExtent;
-import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
-import com.sk89q.worldedit.extent.inventory.BlockBag;
-import com.sk89q.worldedit.function.operation.Operation;
-import com.sk89q.worldedit.function.pattern.AbstractPattern;
-import com.sk89q.worldedit.function.pattern.Pattern;
-import com.sk89q.worldedit.history.UndoContext;
-import com.sk89q.worldedit.history.change.Change;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
-import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
-import com.sk89q.worldedit.regions.selector.RegionSelectorType;
-import com.sk89q.worldedit.session.ClipboardHolder;
-import com.sk89q.worldedit.session.SessionKey;
-import com.sk89q.worldedit.session.SessionManager;
-import com.sk89q.worldedit.session.SessionOwner;
-import com.sk89q.worldedit.util.auth.AuthorizationException;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
-import com.sk89q.worldedit.util.formatting.text.Component;
-import com.sk89q.worldedit.world.AbstractWorld;
-import com.sk89q.worldedit.world.NullWorld;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
-import com.sk89q.worldedit.world.weather.WeatherTypes;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
-import org.bukkit.util.BlockVector;
-import org.enginehub.piston.CommandManager;
 import teachingtutorials.TeachingTutorials;
 import teachingtutorials.TutorialPlaythrough;
-import teachingtutorials.fundamentalTasks.Command;
-import teachingtutorials.utils.plugins.WorldGuard;
 
-import javax.print.DocFlavor;
-import java.util.*;
+import java.util.HashSet;
 
 public class WorldEdit
 {
@@ -87,41 +44,11 @@ public class WorldEdit
         //Get instance
         com.sk89q.worldedit.WorldEdit worldEdit = com.sk89q.worldedit.WorldEdit.getInstance();
 
-//        //Get the session manager
-//        SessionManager sessionManager = worldEdit.getSessionManager();
-
         //Get the console actor
         Actor consoleActor = BukkitAdapter.adapt(Bukkit.getConsoleSender());
 
-//        //Create an edit session for the console
-//        EditSession consoleEditSession = worldEdit.newEditSessionBuilder().world(correctSelectionRegion.getWorld()).actor(consoleActor).build();
-//
-//        //Get the local session of the console and set the edit session there
-//        LocalSession tempLocalSession = sessionManager.get(consoleActor);
-////        tempLocalSession.remember(consoleEditSession);
-//
-////        //Get the player's edit session
-////        LocalSession localSession = sessionManager.get(WEPlayer);
-//
-////        //Get the player's selection limits
-////        ActorSelectorLimits selectionLimits = ActorSelectorLimits.forActor(WEPlayer);
-//
-////        //Injects the new selection - adjusts the player's selection
-////        playersRegionSelector.selectPrimary(correctSelectionRegion.getMinimumPoint(), selectionLimits);
-////        playersRegionSelector.selectSecondary(correctSelectionRegion.getMaximumPoint(), selectionLimits);
-//
-////        //Gets the player
-////        com.sk89q.worldedit.entity.Player WEPlayer = ;
-//        //Get the player's selection limits
-//        ActorSelectorLimits selectionLimits = ActorSelectorLimits.forActor(BukkitAdapter.adapt(player));
-//
-//        //Gets the temp actor's selection and sets the selection points
-//        RegionSelector actorRegionSelector = tempLocalSession.getRegionSelector(correctSelectionRegion.getWorld());
-//        actorRegionSelector.selectPrimary(correctSelectionRegion.getMinimumPoint(), selectionLimits);
-//        actorRegionSelector.selectSecondary(correctSelectionRegion.getMaximumPoint(), selectionLimits);
-//
         //Modifies the command
-        //This code is taken from WorldEdit
+        //This code is taken from WorldEdit - See https://enginehub.org/
         int plSep = szCommandLabel.indexOf(':');
         if (plSep >= 0 && plSep < szCommandLabel.length() +1)
         {
@@ -135,8 +62,6 @@ public class WorldEdit
 
         //The command is now fully formatted correctly
 //        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorial] Command being run via the API: "+szWorldEditCommand);
-
-
         Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorial] Command being run via the console: "+szWorldEditCommand);
 
         //Create the new event listener
@@ -150,14 +75,7 @@ public class WorldEdit
             {
                 final Actor actor = event.getActor();
 
-//                event.getExtent().getMinimumPoint() = ev
-
-                if (actor==null)// || actor.getUniqueId().equals(tempActor.getUniqueId()))
-                {
-                    System.out.println("Edit session event detected belonging to a null actor - assuming console - at stage: "+event.getStage().toString());
-                    //Cancel if at a certain stage?
-                }
-                else if (actor.getSessionKey().equals(consoleActor.getSessionKey()))
+                if (actor.getName().equals(consoleActor.getName()))
                 {
                     System.out.println("Edit session event detected belonging to the actor we are listening for - at stage: "+event.getStage().toString());
                 }
@@ -167,11 +85,12 @@ public class WorldEdit
                     return;
                 }
 
+                //Creates the new extent
                 AbstractDelegateExtent blockChangeRecorderExtent = new AbstractDelegateExtent(event.getExtent())
                 {
-                    @Override // Is this not working? It seems to not run this modified setBlock
+                    @Override
                     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) {
-                        System.out.println("A world edit block change has been detected, recording to the given virtual blocks list");
+                        Bukkit.getConsoleSender().sendMessage("\nA world edit block change has been detected, belonging to the listener for task " +iTaskID +". Recording to the given virtual blocks list");
                         onBlockChange(position, block);
                         //return super.setBlock(position, block);
                         return false; // It's unclear whether this should really be used.
@@ -181,17 +100,21 @@ public class WorldEdit
 
                     protected <B extends BlockStateHolder<B>> void onBlockChange(BlockVector3 pt, B block)
                     {
-//                        //This should only ever be a specific stage anyway
+//                        //This should only ever be for one of the 3 stages anyway right?
 //                        if (event.getStage() != EditSession.Stage.BEFORE_CHANGE) {
 //                            return;
 //                        }
-                        //Unregisters the event and deletes the world guard region after 0.5 seconds (10 ticks)
+                        //Unregisters the event after 0.1 seconds (2 ticks)
                         Bukkit.getScheduler().runTaskLater(TeachingTutorials.getInstance(), () ->
                         {
-                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistering world edit listener");
+                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistering world edit listener for task "+iTaskID);
                             worldEdit.getEventBus().unregister(worldEditEditEvent);
-                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistered world edit listener");
-                        }, 10L);
+                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Unregistered world edit listener for task "+iTaskID);
+
+                            int iSize = virtualBlocks.size();
+
+                            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] There were " +iSize + " block changes detected for task "+iTaskID);
+                        }, 2L);
 
 
                         //Calculates the old block
@@ -205,6 +128,10 @@ public class WorldEdit
                         //If there is actually a change of block
                         if (!blockDataBefore.equals(blockDataNew))
                         {
+                            Bukkit.getConsoleSender().sendMessage("There was a change of block: ");
+                            Bukkit.getConsoleSender().sendMessage("New block: " +blockDataNew.getMaterial());
+                            Bukkit.getConsoleSender().sendMessage("Location: " +location.toString());
+
                             //Creates a virtual block
                             VirtualBlock virtualBlock = new VirtualBlock(tutorialPlaythrough, player, location, blockDataNew);
                             //Adds it to the new list
@@ -213,44 +140,29 @@ public class WorldEdit
                     }
                 };
 
-                event.getExtent().setBlock() // Try this maybe
-
+                //Sets the new extent into the event
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Setting the extent");
                 event.setExtent(blockChangeRecorderExtent);
-
-                event.getExtent().setBlock() // Try this maybe
             }
         };
 
-        //Temporarily block player's world edit output
-//        To do;
-        //If we create a new actor then it should be fine right?
-        //As long as we extract the selection correctly
-
-        //Temporarily allow worldguard access
-        //Tbh just make it the whole world
-//        WorldGuard.addToGlobalRegion(bukkitWorld, player);
-//        WorldGuard.createNewRegion(iTaskID+"", BukkitAdapter.adapt(bukkitWorld), player, correctSelectionRegion.getMinimumPoint(), correctSelectionRegion.getMaximumPoint());
-
-//        //Performs the WE command via the API
-//        CommandEvent commandEvent = new CommandEvent(consoleActor, szWorldEditCommand);
-//        PlatformCommandManager platformCommandManager = worldEdit.getPlatformManager().getPlatformCommandManager();
-//
         Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Sending command: "+szWorldEditCommand);
-//        platformCommandManager.handleCommand(commandEvent);
+
         Bukkit.getScheduler().runTask(TeachingTutorials.getInstance(), () ->
         {
             try
             {
+                //Sets the selection
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Adjusting the selection");
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/world "+tutorialPlaythrough.getLocation().getLocationID());
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/pos1 " + ((CuboidRegion) correctSelectionRegion.getRegion()).getPos1().toParserString());
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "/pos2 " + ((CuboidRegion) correctSelectionRegion.getRegion()).getPos2().toParserString());
 
-                //Register the event
+                //Registers the world change event listener
                 worldEdit.getEventBus().register(worldEditEditEvent);
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] World edit change event listener registered");
 
+                //Runs the command
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Sending the command");
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), szWorldEditCommand);
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Command sent");

--- a/src/main/java/teachingtutorials/utils/plugins/WorldGuard.java
+++ b/src/main/java/teachingtutorials/utils/plugins/WorldGuard.java
@@ -8,11 +8,14 @@ import com.sk89q.worldguard.internal.platform.WorldGuardPlatform;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+
+import java.util.Set;
 
 public class WorldGuard
 {
@@ -44,8 +47,159 @@ public class WorldGuard
             members.clear();
             owners.clear();
 
+            //Adds the creator as an owner
+            owners.addPlayer(creator.getUniqueId());
+        }
+
+        try {
+            regionManager.saveChanges();
+        } catch (StorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Adds a player to the global region of this world as a member
+     * @param bukkitWorld The world to add the player to
+     * @param player The player to add to the world as a member
+     */
+    public static void addToGlobalRegion(org.bukkit.World bukkitWorld, Player player)
+    {
+        WorldGuardPlatform platform = com.sk89q.worldguard.WorldGuard.getInstance().getPlatform();
+        World world = BukkitAdapter.adapt(bukkitWorld);
+        RegionManager regionManager = platform.getRegionContainer().get(world);
+
+        //Gets the global region
+        ProtectedRegion protectedRegion = regionManager.getRegion(ProtectedRegion.GLOBAL_REGION);
+
+        if (protectedRegion == null)
+        {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED +"[TeachingTutorials] Could not set worldguard perms for world");
+        }
+        else
+        {
+            //Gets the members
+            DefaultDomain members = protectedRegion.getMembers();
+
             //Adds the creator as a member
-            members.addPlayer(creator.getUniqueId());
+            members.addPlayer(player.getUniqueId());
+        }
+
+        try {
+            regionManager.saveChanges();
+        } catch (StorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void removeFromGlobalRegion(org.bukkit.World bukkitWorld, Player player)
+    {
+        WorldGuardPlatform platform = com.sk89q.worldguard.WorldGuard.getInstance().getPlatform();
+        World world = BukkitAdapter.adapt(bukkitWorld);
+        RegionManager regionManager = platform.getRegionContainer().get(world);
+
+        //Gets the global region
+        ProtectedRegion protectedRegion = regionManager.getRegion(ProtectedRegion.GLOBAL_REGION);
+
+        if (protectedRegion == null)
+        {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED +"[TeachingTutorials] Could not set worldguard perms for world");
+        }
+        else
+        {
+            //Gets the members
+            DefaultDomain members = protectedRegion.getMembers();
+
+            //Adds the creator as a member
+            members.removePlayer(player.getUniqueId());
+        }
+
+        try {
+            regionManager.saveChanges();
+        } catch (StorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Creates a new cuboid world guard region
+     * @param szName The ID of the new region
+     * @param world The world to add this region to
+     * @param player Player to add as a member
+     * @param minimumPoint Minimum x/y block of the region
+     * @param maximumPoint Maximum
+     */
+    public static void createNewRegion(String szName, World world, Player player, BlockVector3 minimumPoint, BlockVector3 maximumPoint)
+    {
+        WorldGuardPlatform platform = com.sk89q.worldguard.WorldGuard.getInstance().getPlatform();
+//        World world = BukkitAdapter.adapt(bukkitWorld);
+        RegionManager regionManager = platform.getRegionContainer().get(world);
+
+
+        ProtectedRegion protectedRegion = new ProtectedCuboidRegion(szName, minimumPoint, maximumPoint);
+        regionManager.addRegion(protectedRegion);
+
+        if (protectedRegion == null)
+        {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED +"[TeachingTutorials] Could not set worldguard perms for world");
+        }
+        else
+        {
+            //Gets the members and owners
+            DefaultDomain owners = protectedRegion.getOwners();
+            DefaultDomain members = protectedRegion.getMembers();
+
+            //Clears all members and owners
+            members.clear();
+            owners.clear();
+
+            //Adds the creator as a member
+            members.addPlayer(player.getUniqueId());
+        }
+
+        try {
+            regionManager.saveChanges();
+        } catch (StorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Removes a world guard region
+     * @param szRegionName The ID of the region to delete
+     * @param world The world which this region belongs in
+     * @return Whether the region got removed or not
+     */
+    public static boolean removeRegion(String szRegionName, World world)
+    {
+        WorldGuardPlatform platform = com.sk89q.worldguard.WorldGuard.getInstance().getPlatform();
+        RegionManager regionManager = platform.getRegionContainer().get(world);
+
+        try
+        {
+            Set<ProtectedRegion> removedRegions = regionManager.removeRegion(szRegionName);
+            regionManager.saveChanges();
+            if (removedRegions.size() > 0)
+            {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Some regions were removed");
+                return true;
+            }
+            else
+            {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] No regions were removed");
+                return false;
+            }
+
+        }
+        catch (StorageException e)
+        {
+            e.printStackTrace();
+            return false;
+        }
+        catch (NullPointerException npe)
+        {
+            npe.printStackTrace();
+            return false;
         }
     }
 }


### PR DESCRIPTION
Changes the virtual blocks mechanism, and in the process fixes a bug where blocks would not be overrided properly when replaced in game.

Changes the world edit mechanism to remove hardcoded world edit code and instead allow all world edit commands such as //set, //line, //stack, //fill within one mechanism.