### PR TITLE
Configures the delay between recording and setting blocks in WE calculations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.bteuk</groupId>
     <artifactId>TeachingTutorials</artifactId>
-    <version>1.1.0-Beta8.1.3</version>
+    <version>1.1.0-Beta8.1.4</version>
     <packaging>jar</packaging>
 
     <name>TeachingTutorials</name>

--- a/src/main/java/teachingtutorials/utils/WorldEditCalculation.java
+++ b/src/main/java/teachingtutorials/utils/WorldEditCalculation.java
@@ -267,6 +267,9 @@ public class WorldEditCalculation
 
             Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Recording the world blocks for: "+iTaskID);
 
+            //Marks that virtual blocks have been placed on the real world
+            teachingtutorials.utils.WorldEdit.setVirtualBlocksOnRealWorld();
+
             //Records the real blocks of the world at the virtual blocks location
             for (int i = 0 ; i < iSize ; i++)
             {
@@ -275,7 +278,7 @@ public class WorldEditCalculation
                 {
                     //Store the block details in local objects
                     Location location = virtualBlockLocations[iPosition].location;
-                    BlockData realBlock = world.getBlockData(location).clone();
+                    BlockData realBlock = world.getBlockData(location).clone(); //This actually gets run asynchronously and takes over a second sometimes
 
                     //Adds the real block at this location to the list
                     realBlocks.put(location, realBlock);
@@ -287,9 +290,6 @@ public class WorldEditCalculation
 //                            +") with material: "+realBlock.getMaterial());
                 }
             }
-
-            //Marks that virtual blocks have been placed on the real world
-            teachingtutorials.utils.WorldEdit.setVirtualBlocksOnRealWorld();
 
             //We set virtual blocks to the world so that it takes them into account in the WE calculation
             //Wait 15 ticks before setting the virtual blocks to the world because the recording of the blocks (see for loop above)
@@ -335,7 +335,7 @@ public class WorldEditCalculation
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), szWorldEditCommand);
                     Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"[TeachingTutorials] Command sent for task: "+iTaskID);
                 }
-            }, 15L);
+            }, TeachingTutorials.getInstance().getConfig().getLong("BlockRecordDelay"));
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,3 +20,5 @@ Lobby_Pitch:
 Lobby_Yaw:
 Hologram_Max_Width: 40
 Min_Y: -100
+#Do not decrease below 25 unless you know what you are doing
+BlockRecordDelay: 25


### PR DESCRIPTION
The world.getBlockData() function appears to be asynchronous so it is important to wait a sufficient amount of time after running this before setting new blocks. Unfortunately it is not clear how long this time needs to be. The delay is defaulted at 25 ticks because 15 ticks was not enough and failed after around 10 run-throughs of the tutorial.