### PR TITLE
Overhaul virtual blocks mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.bteuk</groupId>
     <artifactId>TeachingTutorials</artifactId>
-    <version>1.1.0-Beta8.1.4</version>
+    <version>1.1.0-Beta8.1.5</version>
     <packaging>jar</packaging>
 
     <name>TeachingTutorials</name>

--- a/src/main/java/teachingtutorials/TutorialPlaythrough.java
+++ b/src/main/java/teachingtutorials/TutorialPlaythrough.java
@@ -9,10 +9,9 @@ import teachingtutorials.tutorials.Stage;
 import teachingtutorials.tutorials.Tutorial;
 import teachingtutorials.utils.Mode;
 import teachingtutorials.utils.User;
-import teachingtutorials.utils.VirtualBlockLocation;
+import teachingtutorials.utils.VirtualBlockGroup;
 
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
 
 //To be extended by lesson and new location
 //They both share a lot of data and processes, and they are also rather similar in the user experience as well
@@ -90,17 +89,25 @@ public abstract class TutorialPlaythrough
         fallListener.unregister();
 
         //Removes virtual blocks
-        ConcurrentHashMap<VirtualBlockLocation, BlockData> virtualBlocks = plugin.virtualBlocks;
-        int iSize;
-        iSize = virtualBlocks.size();
-        VirtualBlockLocation[] locations = virtualBlocks.keySet().toArray(VirtualBlockLocation[]::new);
+        ArrayList<VirtualBlockGroup<org.bukkit.Location, BlockData>> virtualBlockGroups = plugin.getVirtualBlockGroups();
 
-        for (int i = 0 ; i < iSize ; i++)
+        VirtualBlockGroup<org.bukkit.Location, BlockData> virtualBlockGroup;
+
+        //Goes through the list of the plugins active virtual block groups
+        for (int i = 0 ; i < virtualBlockGroups.size() ; i++)
         {
-            if (locations[i].isFromTutorial(this))
+            virtualBlockGroup = virtualBlockGroups.get(i);
+
+            //Checks whether the virtual block group is of this tutorial playthrough
+            if (virtualBlockGroup.isOfPlaythrough(this))
             {
-                virtualBlocks.remove(locations[i]);
-                locations[i].removeAndReset();
+                //Removes the list from the plugin's list of lists
+                this.plugin.removeVirtualBlocks(virtualBlockGroup);
+
+                //Resets the blocks back to the original state for the players
+                virtualBlockGroup.removeBlocks();
+
+                i--;
             }
         }
 

--- a/src/main/java/teachingtutorials/fundamentalTasks/Command.java
+++ b/src/main/java/teachingtutorials/fundamentalTasks/Command.java
@@ -1,36 +1,27 @@
 package teachingtutorials.fundamentalTasks;
 
-import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.regions.CuboidRegion;
-import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.util.BlockVector;
 import teachingtutorials.TeachingTutorials;
 import teachingtutorials.newlocation.DifficultyListener;
 import teachingtutorials.tutorials.Group;
 import teachingtutorials.tutorials.LocationTask;
 import teachingtutorials.utils.Display;
-import teachingtutorials.utils.VirtualBlock;
 import teachingtutorials.utils.WorldEdit;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
 
 enum commandType
 {

--- a/src/main/java/teachingtutorials/fundamentalTasks/Place.java
+++ b/src/main/java/teachingtutorials/fundamentalTasks/Place.java
@@ -15,7 +15,6 @@ import teachingtutorials.newlocation.DifficultyListener;
 import teachingtutorials.tutorials.Group;
 import teachingtutorials.tutorials.LocationTask;
 import teachingtutorials.utils.Display;
-import teachingtutorials.utils.VirtualBlock;
 
 
 public class Place extends Task implements Listener
@@ -53,7 +52,7 @@ public class Place extends Task implements Listener
         this.fDifficulty = fDifficulty;
 
         //Calculates the virtual block
-        calculateVirtualBlocks();
+        addVirtualBlock();
     }
 
     /**
@@ -146,8 +145,8 @@ public class Place extends Task implements Listener
             //SpotHit is then called from inside the difficulty listener once the difficulty has been established
             //This is what moves it onto the next task
 
-            //Calculates the list of virtual blocks
-            calculateVirtualBlocks();
+            //Adds the virtual block
+            addVirtualBlock();
 
             //Displays the virtual blocks
             displayVirtualBlocks();
@@ -229,11 +228,9 @@ public class Place extends Task implements Listener
     /**
      * Uses the target coords and target material to calculate the virtual block
      */
-    public void calculateVirtualBlocks()
+    public void addVirtualBlock()
     {
-        VirtualBlock virtualPlaceBlock = new VirtualBlock(this.parentGroup.parentStep.parentStage.tutorialPlaythrough, player, player.getWorld(),
-                                                        iTargetCoords[0], iTargetCoords[1], iTargetCoords[2],
-                                                        mTargetMaterial.createBlockData());
-        this.virtualBlocks.put(virtualPlaceBlock.blockLocation, virtualPlaceBlock.blockData);
+        Location location = new Location(this.parentGroup.parentStep.parentStage.tutorialPlaythrough.getLocation().getWorld(), iTargetCoords[0], iTargetCoords[1], iTargetCoords[2]);
+        this.virtualBlocks.put(location, mTargetMaterial.createBlockData());
     }
 }

--- a/src/main/java/teachingtutorials/fundamentalTasks/Task.java
+++ b/src/main/java/teachingtutorials/fundamentalTasks/Task.java
@@ -2,18 +2,18 @@ package teachingtutorials.fundamentalTasks;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import teachingtutorials.TeachingTutorials;
 import teachingtutorials.tutorials.Group;
 import teachingtutorials.tutorials.Lesson;
-import teachingtutorials.utils.VirtualBlockLocation;
+import teachingtutorials.utils.VirtualBlockGroup;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class Task
 {
@@ -52,7 +52,7 @@ public class Task
     /**
      * A list of virtual blocks which are to be displayed as a result of task completion
      */
-    protected ConcurrentHashMap<VirtualBlockLocation, BlockData> virtualBlocks;
+    protected VirtualBlockGroup<Location, BlockData> virtualBlocks;
 
     public void register()
     {
@@ -93,7 +93,7 @@ public class Task
         this.szDetails = szDetails;
         this.type = szType;
 
-        this.virtualBlocks = new ConcurrentHashMap<>();
+        this.virtualBlocks = new VirtualBlockGroup<>(this.parentGroup.parentStep.parentStage.tutorialPlaythrough);
 
         this.bCreatingNewLocation = bCreatingNewLocation;
     }
@@ -124,34 +124,19 @@ public class Task
     }
 
     /**
-     * Adds all of the virtual blocks of this task to the plugin's virtual blocks list
+     * Adds the list of virtual blocks of this task to the plugin's virtual blocks list
      */
     public void displayVirtualBlocks()
     {
-        int iSize = virtualBlocks.size();
-        VirtualBlockLocation[] locations = virtualBlocks.keySet().toArray(VirtualBlockLocation[]::new);
-        BlockData[] blockData = virtualBlocks.values().toArray(BlockData[]::new);
-
-        for (int i = 0; i < iSize; i++)
-        {
-            //The put will overwrite any existing virtual blocks at this location
-            plugin.virtualBlocks.put(locations[i], blockData[i]);
-        }
+        plugin.addVirtualBlocks(virtualBlocks);
     }
 
     /**
-     * Removes all of the virtual blocks of this task from the plugin's virtual blocks list
+     * Removes the list of virtual blocks of this task from the plugin's list of virtual block groups
      */
     protected void removeVirtualBlocks()
     {
-        int iSize = virtualBlocks.size();
-        VirtualBlockLocation[] locations = virtualBlocks.keySet().toArray(VirtualBlockLocation[]::new);
-
-        for (int i = 0; i < iSize; i++)
-        {
-            plugin.virtualBlocks.remove(locations[i]);
-        }
-        plugin.getLogger().info(ChatColor.AQUA +"All virtual blocks from task with task id " +iTaskID +" removed");
+        plugin.removeVirtualBlocks(virtualBlocks);
     }
 
     public void newLocationSpotHit()

--- a/src/main/java/teachingtutorials/tutorials/Group.java
+++ b/src/main/java/teachingtutorials/tutorials/Group.java
@@ -149,6 +149,13 @@ public class Group
         currentTask.unregister();
     }
 
+    /**
+     * Retrieves from the database the list of groups for the specified step
+     * @param player The player playing through the tutorial
+     * @param plugin The instance of the plugin
+     * @param step The stage for which all groups must be retrieved
+     * @return A list of groups for this step
+     */
     public static ArrayList<Group> fetchGroupsByStepID(Player player, TeachingTutorials plugin, Step step)
     {
         ArrayList<Group> groups = new ArrayList<>();

--- a/src/main/java/teachingtutorials/tutorials/Lesson.java
+++ b/src/main/java/teachingtutorials/tutorials/Lesson.java
@@ -134,7 +134,11 @@ public class Lesson extends TutorialPlaythrough
         return true;
     }
 
-    //Resumes a previously started lesson
+    /**
+     * Resumes a previously started lesson
+     * @param bResetProgress Whether to reset the progress to stage 1 step 1
+     * @return Whether or not the lesson resumed successfully
+     */
     private boolean resumeLesson(boolean bResetProgress)
     {
         //Fetches the tutorial ID, the location, the stage and the step the player is at in their current tutorial
@@ -150,12 +154,16 @@ public class Lesson extends TutorialPlaythrough
                 +", Tutorial ID = " +this.tutorial.getTutorialID()
                 +" and LocationID = "+this.location.getLocationID());
 
-        //Redisplays all virtual blocks
+        //Redisplays virtual blocks of steps already completed
+        //Goes through all stages up to the current
         for (int i = 0 ; i < iStageIndex ; i++)
         {
+            //Checks whether we are at their current stage or not
             if (i != iStageIndex - 1)
+                //If this is not the current stage, display virtual blocks of all steps
                 stages.get(i).displayAllVirtualBlocks(0);
             else
+                //Displays virtual blocks up to the step they are on
                 stages.get(i).displayAllVirtualBlocks(iStepToStart);
         }
 

--- a/src/main/java/teachingtutorials/tutorials/Stage.java
+++ b/src/main/java/teachingtutorials/tutorials/Stage.java
@@ -111,24 +111,36 @@ public class Stage
         return (iOrder == 1);
     }
 
+    /**
+     * Displays the virtual blocks of all tasks in all steps of this stage up to but not including the iStepToStartTH step
+     * @param iStepToStart The step at which to start the lesson at (this is not zero indexed. The first step has iStepToStart = 1).
+     *                     <p> </p>
+     *                     For clarity, if iStepToStart is 1, no virtual blocks from will be displayed from this stage.
+     *                     <p>If iStepToStart = 2, only the virtual blocks from the first step (and all previous stages) will be displayed at the start of the lesson.</p>
+     */
     public void displayAllVirtualBlocks(int iStepToStart)
     {
-        //Gets the steps from the DB
+        //Gets the steps of this stage from the DB
         fetchAndInitialiseSteps();
 
+        //The number of steps to display the virtual blocks for
         int iNumSteps;
 
-        if (iStepToStart == 0)
+        if (iStepToStart <= 1)
             iNumSteps = steps.size();
         else
             iNumSteps = iStepToStart - 1;
 
+        //Calls each step to display all relevant virtual blocks
         for (int i = 0 ; i < iNumSteps ; i++)
         {
             steps.get(i).displayAllVirtualBlocks();
         }
     }
 
+    /**
+     * Fetches the list of steps of this stage from the database and stores this in {@link #steps}. The list is ordered.
+     */
     private void fetchAndInitialiseSteps()
     {
         //Gets a list of all of the steps of the specified stage and loads each with the relevant data.

--- a/src/main/java/teachingtutorials/tutorials/Step.java
+++ b/src/main/java/teachingtutorials/tutorials/Step.java
@@ -113,6 +113,9 @@ public class Step
         return selectionCompleteHold;
     }
 
+    /**
+     * Displays the virtual blocks of all tasks is this step
+     */
     public void displayAllVirtualBlocks()
     {
         //Gets the groups from the DB
@@ -125,6 +128,11 @@ public class Step
         }
     }
 
+    /**
+     * Fetches the list of groups of this step from the database and stores this in {@link #groups}.
+     * <p> </p>
+     * The order of groups does not matter and as such the order that they are fetched and stored in doesn't matter.
+     */
     private void fetchAndInitialiseGroups()
     {
         groups = Group.fetchGroupsByStepID(player, plugin, this);

--- a/src/main/java/teachingtutorials/utils/VirtualBlockGroup.java
+++ b/src/main/java/teachingtutorials/utils/VirtualBlockGroup.java
@@ -1,0 +1,137 @@
+package teachingtutorials.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import teachingtutorials.TutorialPlaythrough;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An extension of a concurrent hashmap for lists of virtual block
+ * @param <K> Key
+ * @param <V> Value
+ */
+public class VirtualBlockGroup<K, V> extends ConcurrentHashMap<K,V>
+{
+    private final TutorialPlaythrough tutorialPlaythrough;
+
+    //A list of spies also viewing the virtual blocks
+    private ArrayList<Player> spies = new ArrayList<>();
+
+    public VirtualBlockGroup(TutorialPlaythrough tutorialPlaythrough)
+    {
+        this.tutorialPlaythrough = tutorialPlaythrough;
+    }
+
+    /**
+     * Returns whether this VirtualBlockGroup belongs to the given tutorial playthrough
+     * @param tutorialPlaythrough
+     * @return True if the given tutorial playthrough and the tutorialPlaythrough of this VirtualBlockGroup are equal. False if not.
+     */
+    public boolean isOfPlaythrough(TutorialPlaythrough tutorialPlaythrough)
+    {
+        return tutorialPlaythrough.equals(this.tutorialPlaythrough);
+    }
+
+    /**
+     * Displays the virtual blocks to the player and all spies
+     */
+    public void displayBlocks()
+    {
+        //Sends the changes to the player
+        tutorialPlaythrough.getCreatorOrStudent().player.sendMultiBlockChange((Map<Location, BlockData>) this);
+
+        //Sends the changes to the spies
+        int iNumSpies = spies.size();
+        int i;
+        for (i = 0 ; i < iNumSpies ; i++)
+        {
+            spies.get(i).sendMultiBlockChange((Map<Location, BlockData>) this);
+        }
+    }
+
+    /**
+     * Removes the virtual blocks from the player and all spies, sets their views back to the real world.
+     */
+    public void removeBlocks()
+    {
+        //Creates a map holding the world's real data at the locations of the virtual blocks
+        Map<Location, BlockData> realWorldBlocks = getRealBlocks();
+
+        //Sends the changes to the player
+        tutorialPlaythrough.getCreatorOrStudent().player.sendMultiBlockChange(realWorldBlocks);
+
+        //Sends the changes to the spies
+        int iNumSpies = spies.size();
+        int i;
+        for (i = 0 ; i < iNumSpies ; i++)
+        {
+            spies.get(i).sendMultiBlockChange(realWorldBlocks);
+        }
+    }
+
+    /**
+     * Adds all of the virtual blocks in this list to the actual world.
+     * <p> </p>
+     * USE WITH EXTREME CAUTION!
+     * <p> </p>
+     */
+    public void addBlocksToWorld()
+    {
+        //Store a reference to the world locally
+        World worldToSet = tutorialPlaythrough.getLocation().getWorld();
+
+        //Gets the list of locations and block data for this list
+        final Location[] locations = this.keySet().stream().toArray(Location[]::new);
+        final BlockData[] virtualBlockData = this.values().toArray(BlockData[]::new);
+        int iLocations = locations.length;
+
+        //Get the blocks in the world
+        for (int i = 0 ; i < iLocations ; i++)
+        {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA +"Setting a virtual block to the actual world");
+            worldToSet.setBlockData(locations[i], virtualBlockData[i]);
+        }
+    }
+
+    /**
+     * Creates a map of location to real blocks at the locations of the virtual blocks of this list
+     * @return A list of the real world blocks at locations of the virtual blocks of this list
+     */
+    public Map<Location, BlockData> getRealBlocks()
+    {
+        //Store a reference to the world locally
+        World worldToRead = tutorialPlaythrough.getLocation().getWorld();
+
+        //Gets the list of locations for this list
+        Location[] virtualBlockLocations = this.keySet().stream().toArray(Location[]::new);
+        int iLocations = virtualBlockLocations.length;
+
+        //Creates a map holding the world's real data at the locations of the virtual blocks
+        Map<Location, BlockData> realWorldBlocks = new HashMap<>(iLocations);
+        for (int i = 0 ; i < iLocations ; i++)
+        {
+            BlockData realBlock = worldToRead.getBlockData(virtualBlockLocations[i]).clone(); //This actually gets run asynchronously and takes over a second sometimes
+
+//            Bukkit.getConsoleSender().sendMessage(ChatColor.DARK_BLUE +"Block recorded at ("
+//                    +virtualBlockLocations[i].getX()+","
+//                    +virtualBlockLocations[i].getY()+","
+//                    +virtualBlockLocations[i].getZ()
+//                    +") with material: "+realBlock.getMaterial());
+
+            realWorldBlocks.put(virtualBlockLocations[i], realBlock);
+
+        }
+
+        return realWorldBlocks;
+    }
+
+
+}

--- a/src/main/java/teachingtutorials/utils/WorldEdit.java
+++ b/src/main/java/teachingtutorials/utils/WorldEdit.java
@@ -4,12 +4,11 @@ import com.google.common.base.Joiner;
 import com.sk89q.worldedit.regions.RegionSelector;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import teachingtutorials.TutorialPlaythrough;
 
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class WorldEdit
@@ -17,7 +16,7 @@ public class WorldEdit
     /**
      * A queue of pending calculations to be performed
      */
-    public static LinkedList<WorldEditCalculation> pendingCalculations = new LinkedList<>();
+    public static ConcurrentLinkedQueue<WorldEditCalculation> pendingCalculations = new ConcurrentLinkedQueue<>();
     private static AtomicBoolean bCurrentCalculationOngoing = new AtomicBoolean(false);
 
     //Records whether there are virtual blocks on the real world
@@ -74,7 +73,7 @@ public class WorldEdit
      * @param tutorialPlaythrough The tutorial playthrough which this task belongs to
      * @return
      */
-    public static void BlocksCalculator(int iTaskID, final ConcurrentHashMap<VirtualBlockLocation, BlockData> virtualBlocks, RegionSelector correctSelectionRegion, String szCommandLabel, String[] szCommandArgs, TutorialPlaythrough tutorialPlaythrough)
+    public static void BlocksCalculator(int iTaskID, final VirtualBlockGroup<Location, BlockData> virtualBlocks, RegionSelector correctSelectionRegion, String szCommandLabel, String[] szCommandArgs, TutorialPlaythrough tutorialPlaythrough)
     {
         //1. Modifies the command
         //This code is taken from WorldEdit - See https://enginehub.org/


### PR DESCRIPTION
- Fix for world edit virtual blocks not being displayed on lesson continuation
- Adjust the virtual blocks mechanism to group virtual blocks of each task together. (These groups are then added to the list of groups when they need to be displayed
- The blocks of each task are now given to the player together with the player.sendMultiBlockChanges() method.
- Introduces the functionality for "spies" (no way of adding yourself as a spy is added yet)